### PR TITLE
Update read_fan_speed.py to correct env for python3 on modern Lin…

### DIFF
--- a/read_fan_speed.py
+++ b/read_fan_speed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # -*- coding: utf-8 -*-
 from gpiozero import Button
 import time


### PR DESCRIPTION
…ux systems

The more common way to write python code now uses python3 instead of just python.

Ubuntu 24.04 does not have a /usr/bin/python, but it does have usr/bin/python3.

```
$ cat /etc/*release && ls -al /usr/bin/python*
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=24.04
DISTRIB_CODENAME=noble
DISTRIB_DESCRIPTION="Ubuntu 24.04.1 LTS"
PRETTY_NAME="Ubuntu 24.04.1 LTS"
NAME="Ubuntu"
VERSION_ID="24.04"
VERSION="24.04.1 LTS (Noble Numbat)"
VERSION_CODENAME=noble
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=noble
LOGO=ubuntu-logo
lrwxrwxrwx 1 root root      10 Aug  7 17:44 /usr/bin/python3 -> python3.12
-rwxr-xr-x 1 root root 7843560 Nov  6 18:32 /usr/bin/python3.12
```

This pull request remedies this on modern debian-based systems. I believe this also is a fix for modern EL distros as well, but I don't currently have a machine to test that fact out on.

What might be a better idea (for both the reader and the controller) would be to put them into docker containers and let you just do a docker run command in order to avoid these odd environment requirements that different distros have and then just ignore my pull request in that instance.