### PR TITLE
Update read_fan_speed.py

### DIFF
--- a/read_fan_speed.py
+++ b/read_fan_speed.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 from gpiozero import Button
 import time


### PR DESCRIPTION
update read_fan_speed.py to conform to standard python convention of using /usr/bin/env python3 rather than relying on varying paths you can wind up with via various distributions.

This change will match the fan_controller.py's use of python env.