### PR TITLE
[FIX] Fan control script, read fan speed script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,63 @@
 # Compute Blade PWM Fan Control
 
-This is a simple script to control your pwm fan on compute blade.
+Simple fan control and tach read scripts for the Compute Blade fan unit.
+
+[Fan Unit Documentation](https://docs.computeblade.com/fan-unit)
 
 ## Install GPIO Zero
 
 ### apt
+
 GPIO Zero is packaged in the apt repositories of Raspberry Pi OS, Debian and Ubuntu. It is also available on [PyPI](https://pypi.org/project/gpiozero/).
+
 ```bash
 sudo apt update
 sudo apt install python3-gpiozero
 ```
 
 ### pip
+
 If you’re using another operating system on your Raspberry Pi, you may need to use pip to install GPIO Zero instead. Install pip using [get-pip](https://pip.pypa.io/en/stable/installing/) and then type:
+
 ```bash
 sudo pip3 install gpiozero
 ```
+
+## Usage
+
+### Scripts
+
+- `fan_control.py`: Drives PWM on GPIO12 and reads CPU temperature to set speed.
+  - Profiles: `linear`, `ease_in`, `ease_out`, `ease_in_out`.
+  - Profile file: `/etc/fan-control/profile` (single word).
+  - Must be run as root for GPIO permissions.
+- `read_fan_speed.py`: Reads tach pulses on GPIO13 and prints RPM.
+
+### Fan Unit Connections
+
+- J1 is the control node (only J1 can drive PWM). It can also read the tach signal.
+- J2 can read tach signals, but cannot control PWM.
+
+### Profile File
+
+The fan control script supports some fan easing curves. Create the profile file with a single word inside:
+
+```bash
+sudo mkdir -p /etc/fan-control
+echo ease_out | sudo tee /etc/fan-control/profile
+```
+
+Valid profiles:
+
+| Profile       | Behavior                                               |
+| ------------- | ------------------------------------------------------ |
+| `linear` 🔹   | Speed increases linearly with temperature              |
+| `ease_in`     | Starts slow, ramps faster at higher temps              |
+| `ease_out`    | Ramps quickly, then levels off                         |
+| `ease_in_out` | Slow at low temps, faster in the middle, smooth finish |
+
+🔹 Default fan profile when not set
+
+## Notes
+
+- GPIO13 is reserved for tach reads on the other node; PWM control uses GPIO12.

--- a/fan_control.py
+++ b/fan_control.py
@@ -1,5 +1,7 @@
 #! /usr/bin/env python3
-from gpiozero import PhaseEnableMotor
+from gpiozero import PWMOutputDevice
+from enum import Enum
+import os
 import time
 import signal
 import sys
@@ -7,19 +9,42 @@ import sys
 # The Noctua PWM control actually wants 25 kHz (kilo!), see page 6 on:
 # https://noctua.at/pub/media/wysiwyg/Noctua_PWM_specifications_white_paper.pdf
 
-PWM_FREQ = 25           # [Hz] PWM frequency
+# Notes on PWM frequency:
+# - The Noctua spec calls for ~25 kHz, but the lgpio backend on this hardware
+#   rejects 11–25 kHz and only accepts up to 10 kHz.
+# - At 10 kHz, the fan tended to clamp to a higher minimum RPM (less low‑speed control).
+# - At 100 Hz, the fan can reach a lower stable speed (≈5% duty yielded ~450 RPM),
+#   even though very low duty cycles may stutter.
+# - We choose 100 Hz here to preserve low‑RPM control; increase if you prefer
+#   smoother PWM at the expense of a higher minimum speed.
+PWM_FREQ_HZ = 100       # [Hz] PWM frequency (default backend rate)
 
-FAN_PIN = 12            # BCM pin used to drive PWM fan
-TACH_PIN = 13           
+PWM_PIN = 12            # BCM pin used to drive PWM fan
+TACH_PIN = 13           # Reserved for tach read on the other node
 WAIT_TIME = 1           # [s] Time to wait between each refresh
 
 OFF_TEMP = 40           # [°C] temperature below which to stop the fan
 MIN_TEMP = 45           # [°C] temperature above which to start the fan
 MAX_TEMP = 70           # [°C] temperature at which to operate at max fan speed
-FAN_LOW = 1
-FAN_HIGH = 100
-FAN_MAX = 100
-FAN_GAIN = float(FAN_HIGH - 0) / float(MAX_TEMP - MIN_TEMP)
+
+FAN_PROFILE_PATH = "/etc/fan-control/profile"
+
+class FanProfile(Enum):
+    LINEAR = "linear"
+    EASE_IN = "ease_in"
+    EASE_OUT = "ease_out"
+    EASE_IN_OUT = "ease_in_out"
+
+    @classmethod
+    def from_string(cls, value: str):
+        normalized = value.strip().lower()
+        mapping = {
+            "linear": cls.LINEAR,
+            "ease_in": cls.EASE_IN,
+            "ease_out": cls.EASE_OUT,
+            "ease_in_out": cls.EASE_IN_OUT,
+        }
+        return mapping.get(normalized)
 
 
 def getCpuTemperature():
@@ -27,20 +52,154 @@ def getCpuTemperature():
         return float(f.read()) / 1000
 
 
-def handleFanSpeed(fan:PhaseEnableMotor, temperature:float):
-    if temperature > MIN_TEMP:
-        delta = min(temperature, MAX_TEMP) - MIN_TEMP
-        fan.forward(FAN_LOW + delta * FAN_GAIN)
-        
-    elif temperature < OFF_TEMP:
-        fan.stop()
+def clamp_speed(speed: float) -> float:
+    return max(0.0, min(1.0, speed))
+
+
+def normalize_temperature(temperature: float) -> float:
+    if MAX_TEMP <= MIN_TEMP:
+        return 1.0 if temperature >= MAX_TEMP else 0.0
+    if temperature <= MIN_TEMP:
+        return 0.0
+    if temperature >= MAX_TEMP:
+        return 1.0
+    return (temperature - MIN_TEMP) / (MAX_TEMP - MIN_TEMP)
+
+
+def linear_curve(progress: float) -> float:
+    return progress
+
+
+def ease_in_curve(progress: float) -> float:
+    return progress * progress * progress
+
+
+def ease_out_curve(progress: float) -> float:
+    return (progress - 1) * (progress - 1) * (progress - 1) + 1
+
+
+def ease_in_out_curve(progress: float) -> float:
+    if progress < 0.5:
+        return 0.5 * ease_in_curve(2 * progress)
+    return 0.5 * ease_out_curve(2 * progress - 1) + 0.5
+
+
+def select_curve(profile: FanProfile):
+    if profile == FanProfile.EASE_IN:
+        return ease_in_curve
+    if profile == FanProfile.EASE_OUT:
+        return ease_out_curve
+    if profile == FanProfile.EASE_IN_OUT:
+        return ease_in_out_curve
+    return linear_curve
+
+
+def get_profile_override():
+    try:
+        with open(FAN_PROFILE_PATH) as handle:
+            raw = handle.read().strip()
+    except FileNotFoundError:
+        return None
+    except OSError as exc:
+        print(
+            f"{FAN_PROFILE_PATH}: read failed ({exc}); defaulting to linear.",
+            file=sys.stderr,
+        )
+        return None
+
+    if not raw:
+        return None
+
+    profile = FanProfile.from_string(raw)
+    if profile is None:
+        print(
+            f"{FAN_PROFILE_PATH}: unknown profile '{raw}'; defaulting to linear.",
+            file=sys.stderr,
+        )
+    return profile
+
+
+def get_lgpio_factory():
+    try:
+        from gpiozero.pins.lgpio import LGPIOFactory
+    except Exception as exc:
+        print(
+            f"LGPIOFactory unavailable ({exc}); falling back to default pin factory.",
+            file=sys.stderr,
+        )
+        return None
+
+    try:
+        return LGPIOFactory()
+    except Exception as exc:
+        print(
+            f"Failed to initialize LGPIOFactory ({exc}); using default pin factory.",
+            file=sys.stderr,
+        )
+        return None
+
+
+def ensure_working_dir():
+    try:
+        cwd = os.getcwd()
+    except FileNotFoundError:
+        cwd = None
+
+    if not cwd or not os.path.isdir(cwd):
+        fallback = "/tmp"
+        print(
+            f"Working directory missing; lgpio needs a writable directory to create "
+            f"its .lgd-nfy* pipe. Falling back to {fallback}.",
+            file=sys.stderr,
+        )
+        os.chdir(fallback)
+        return
+
+    if not os.access(cwd, os.W_OK):
+        fallback = "/tmp"
+        print(
+            f"Working directory '{cwd}' is not writable; lgpio needs a writable "
+            f"directory to create its .lgd-nfy* pipe. Consider running as root, "
+            f"adjusting permissions, or setting a WorkingDirectory= in systemd. "
+            f"Falling back to {fallback}.",
+            file=sys.stderr,
+        )
+        os.chdir(fallback)
+
+
+def pwm_for_temperature(temperature: float, curve_fn) -> float:
+    if temperature <= OFF_TEMP:
+        return 0.0
+    if temperature < MIN_TEMP:
+        return 0.0
+    progress = normalize_temperature(temperature)
+    return clamp_speed(curve_fn(progress))
+
+
+def handleFanSpeed(fan: PWMOutputDevice, temperature: float, curve_fn):
+    speed = pwm_for_temperature(temperature, curve_fn)
+    if speed <= 0.0:
+        fan.off()
+    else:
+        fan.value = speed
 
 
 try:
     signal.signal(signal.SIGTERM, lambda *args: sys.exit(0))
-    fan = PhaseEnableMotor(FAN_PIN, TACH_PIN, pwm=True)
+    ensure_working_dir()
+    pin_factory = get_lgpio_factory()
+    fan = PWMOutputDevice(PWM_PIN, pin_factory=pin_factory)
+    try:
+        fan.frequency = PWM_FREQ_HZ
+    except Exception as exc:
+        print(
+            f"Failed to set PWM frequency to {PWM_FREQ_HZ}Hz: {exc}. Using default.",
+            file=sys.stderr,
+        )
+    profile = get_profile_override() or FanProfile.LINEAR
+    curve_fn = select_curve(profile)
     while True:
-        handleFanSpeed(fan, getCpuTemperature())
+        handleFanSpeed(fan, getCpuTemperature(), curve_fn)
         time.sleep(WAIT_TIME)
 
 except KeyboardInterrupt:


### PR DESCRIPTION
This pull request refactors and improves the Compute Blade fan control scripts. The main changes include enhanced documentation, a redesigned PWM fan control script with support for different fan speed profiles, and a more accurate reader script.

**Fan control script enhancements:**

* Replaced the old `PhaseEnableMotor`-based implementation in `fan_control.py` with a new `PWMOutputDevice`-based design, supporting selectable fan speed profiles (`linear`, `ease_in`, `ease_out`, `ease_in_out`) via `/etc/fan-control/profile`.
* Added temperature normalization, easing curve functions, and improved PWM frequency selection logic to allow better low-speed control and compatibility with hardware limitations.
* Improved error handling for pin factory initialization and working directory requirements to ensure reliable operation.

**Fan speed reading improvements:**

* Updated `read_fan_speed.py` to use a thread-safe pulse counting mechanism, providing more accurate RPM readings and avoiding race conditions. [[1]](diffhunk://#diff-06a77c5cfc1673ce33b6886afb3258acb64bbe953ed157608e9ed30ee292cd18R4) [[2]](diffhunk://#diff-06a77c5cfc1673ce33b6886afb3258acb64bbe953ed157608e9ed30ee292cd18L15-R40)

**Documentation improvements:**

* Expanded `README.md` with usage instructions, fan unit connection details, supported fan speed profiles, and example commands for setting the profile file.

These changes make the scripts more flexible and reliable for controlling and monitoring the Compute Blade fan unit.

Fixes #5
Fixes #3 